### PR TITLE
create functional searchbar that filters word list

### DIFF
--- a/components/AddEntryForm/index.js
+++ b/components/AddEntryForm/index.js
@@ -1,7 +1,6 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 import { StyledCard } from "../StyledComponents/StyledCard";
 import { StyledSection } from "../StyledComponents/StyledSection";
-import Heading from "../PageHeading";
 import { convertToKana } from "@/utils/helperFunctions.js";
 
 function AddEntryForm({ handleAddEntry }) {

--- a/components/Entry/index.js
+++ b/components/Entry/index.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 import { StyledCard } from "../StyledComponents/StyledCard";
 
 function Entry({ JPDefinition, JPReading, ENDefinition }) {

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -7,10 +7,13 @@ export default function Navigation() {
     <nav>
       <StyledNavList>
         <li className="inherit-background-color">
-          <StyledNavigationLink href="/words">Words</StyledNavigationLink>
+          <StyledNavigationLink href="/">🏠</StyledNavigationLink>
         </li>
         <li className="inherit-background-color">
-          <StyledNavigationLink href="/add">Add</StyledNavigationLink>
+          <StyledNavigationLink href="/words">📚</StyledNavigationLink>
+        </li>
+        <li className="inherit-background-color">
+          <StyledNavigationLink href="/add">➕</StyledNavigationLink>
         </li>
       </StyledNavList>
     </nav>

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 import Link from "next/link";
 import { device } from "@/utils/globalValues";
 

--- a/components/PageHeading/index.js
+++ b/components/PageHeading/index.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 function Heading({ PageTitle }) {
   return <StyledPageHeading>{PageTitle}</StyledPageHeading>;

--- a/components/SearchBar/index.js
+++ b/components/SearchBar/index.js
@@ -1,0 +1,76 @@
+import { styled } from "styled-components";
+import SearchResults from "../SearchResults";
+import { useState } from "react";
+
+function SearchBar({ query, setQuery, handleSearchInput, searchResults }) {
+  function handleSearchBarSubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+
+    const formData = new FormData(form);
+    const searchQuery = Object.fromEntries(formData);
+
+    setQuery(searchQuery.searchInput);
+    handleSearchInput(searchQuery.searchInput);
+
+    form.reset();
+  }
+
+  //OnChange should still look up the words
+  function handleSearchBarOnInput(query) {
+    setQuery(query);
+    handleSearchInput(query);
+  }
+
+  return (
+    <>
+      <StyledSearchBarForm onSubmit={(event) => handleSearchBarSubmit(event)}>
+        <StyledSearchBar
+          onChange={(event) => handleSearchBarOnInput(event.target.value)}
+          type="text"
+          placeholder="Search..."
+          aria-label="search-bar"
+          name="searchInput"
+        />
+        <StyledSearchBarButton>🔍</StyledSearchBarButton>
+      </StyledSearchBarForm>
+      {query.length > 0 ? (
+        <SearchResults
+          searchResults={searchResults}
+          searchTerm={query}
+          handleSearchInput={handleSearchInput}
+        />
+      ) : (
+        ""
+      )}
+    </>
+  );
+}
+const StyledSearchBarForm = styled.form`
+  width: 80%;
+  display: flex;
+  align-self: center;
+  justify-content: space-between;
+  background-color: var(--white);
+  padding: 10px;
+  border-radius: 25px;
+`;
+
+const StyledSearchBar = styled.input`
+  background-color: inherit;
+  padding: 10px;
+  border: none;
+  width: 100%;
+
+  &::placeholder {
+    color: black;
+  }
+`;
+
+const StyledSearchBarButton = styled.button`
+  border: none;
+  background-color: transparent;
+  padding: 0 15px;
+`;
+
+export default SearchBar;

--- a/components/SearchBar/index.js
+++ b/components/SearchBar/index.js
@@ -1,6 +1,5 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 import SearchResults from "../SearchResults";
-import { useState } from "react";
 
 function SearchBar({ query, setQuery, handleSearchInput, searchResults }) {
   function handleSearchBarSubmit(event) {

--- a/components/SearchResults/index.js
+++ b/components/SearchResults/index.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 import EntriesContainer from "../EntriesContainer";
 
 function SearchResults({ searchResults, searchTerm }) {

--- a/components/SearchResults/index.js
+++ b/components/SearchResults/index.js
@@ -1,0 +1,21 @@
+import { styled } from "styled-components";
+import EntriesContainer from "../EntriesContainer";
+
+function SearchResults({ searchResults, searchTerm }) {
+  return (
+    <>
+      <StyledResultDisplay>
+        {searchResults.length > 0
+          ? `${searchResults.length} results for "${searchTerm}"`
+          : `No results for "${searchTerm}"`}
+      </StyledResultDisplay>
+      <EntriesContainer wordList={searchResults} />
+    </>
+  );
+}
+
+const StyledResultDisplay = styled.p`
+  align-self: center;
+`;
+
+export default SearchResults;

--- a/components/StyledComponents/MainContent.js
+++ b/components/StyledComponents/MainContent.js
@@ -2,6 +2,9 @@ import { device } from "@/utils/globalValues";
 import { styled } from "styled-components";
 
 export const MainContent = styled.main`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   margin-bottom: var(--footer-height);
 
   @media ${device.tablet} {

--- a/components/StyledComponents/MainContent.js
+++ b/components/StyledComponents/MainContent.js
@@ -1,5 +1,5 @@
 import { device } from "@/utils/globalValues";
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 export const MainContent = styled.main`
   display: flex;

--- a/components/StyledComponents/StyledCard.js
+++ b/components/StyledComponents/StyledCard.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 export const StyledCard = styled.section`
   display: flex;

--- a/components/StyledComponents/StyledSection.js
+++ b/components/StyledComponents/StyledSection.js
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 export const StyledSection = styled.section`
   padding: 1rem;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,23 @@
+import Heading from "@/components/PageHeading";
+import SearchBar from "@/components/SearchBar";
+
 import { MainContent } from "@/components/StyledComponents/MainContent";
 
-export default function HomePage() {
+export default function HomePage({
+  query,
+  setQuery,
+  searchResults,
+  handleSearchInput,
+}) {
   return (
     <MainContent>
-      <h1>Flashcard Dictionary Capstone</h1>
+      <Heading PageTitle="Flashcard Dictionary Capstone" />
+      <SearchBar
+        query={query}
+        setQuery={setQuery}
+        handleSearchInput={handleSearchInput}
+        searchResults={searchResults}
+      />
     </MainContent>
   );
 }


### PR DESCRIPTION
Created search bar as per [US4](https://github.com/JudithRe/capstone-flashcard-dictionary/issues/5).
- search bar filters through the existing word list and looks up words in all entry fields. 
- The search bar is available on the home page for now. Added the link to home in the navigation.