### PR TITLE
create editing options both in word list and on word detail page

### DIFF
--- a/components/AddEntryForm/index.js
+++ b/components/AddEntryForm/index.js
@@ -71,14 +71,14 @@ function AddEntryForm({ handleAddEntry }) {
             id="reading"
             name="reading"
           />
-          <StyledSubmitButton type="submit">Add</StyledSubmitButton>
+          <StyledFormSubmitButton type="submit">Add</StyledFormSubmitButton>
         </StyledForm>
       </StyledCard>
     </StyledSection>
   );
 }
 
-const StyledForm = styled.form`
+export const StyledForm = styled.form`
   background-color: inherit;
   display: flex;
   flex-direction: column;
@@ -86,13 +86,13 @@ const StyledForm = styled.form`
   width: 100%;
 `;
 
-const StyledFormLabel = styled.label`
+export const StyledFormLabel = styled.label`
   background-color: inherit;
   margin-bottom: -5px;
   font-weight: 500;
 `;
 
-const StyledFormInput = styled.input`
+export const StyledFormInput = styled.input`
   background-color: inherit;
   padding: 10px;
   border: 1px solid var(--light-grey);
@@ -100,7 +100,7 @@ const StyledFormInput = styled.input`
   box-shadow: inset var(--inset-box-shadow);
 `;
 
-const StyledSubmitButton = styled.button`
+export const StyledFormSubmitButton = styled.button`
   align-self: flex-end;
   background-color: var(--highlight-red);
   color: var(--white);

--- a/components/EditingForm/index.js
+++ b/components/EditingForm/index.js
@@ -41,7 +41,7 @@ function EditingForm({
         word: japaneseInput,
         reading: reading,
       },
-      english: englishInput.split(", "),
+      english: englishInput.split(","),
       study: {
         ...previousEntry.study,
         stage: 0,

--- a/components/EditingForm/index.js
+++ b/components/EditingForm/index.js
@@ -1,0 +1,131 @@
+import styled from "styled-components";
+import { StyledCard } from "../StyledComponents/StyledCard";
+import { StyledSection } from "../StyledComponents/StyledSection";
+import { convertToKana } from "@/utils/helperFunctions.js";
+import { Modal } from "../StyledComponents/Modal";
+import { StyledForm, StyledFormInput, StyledFormLabel } from "../AddEntryForm";
+import {
+  StyledSecondaryButton,
+  StyledSubmitButton,
+} from "../StyledComponents/StyledButtons";
+import WrongIcon from "@/assets/icons/WrongIcon";
+
+function EditingForm({
+  setIsDetailEditMode,
+  previousEnglish,
+  previousJapanese,
+  previousReading,
+  entry,
+  _id,
+  databaseMutate,
+}) {
+  function handleFormSubmit(event) {
+    event.preventDefault();
+    const form = event.target;
+
+    const formData = new FormData(form);
+    const newEntry = Object.fromEntries(formData);
+
+    updateEntry(newEntry, entry);
+    setIsDetailEditMode(false);
+
+    form.reset();
+    form.englishInput.focus();
+  }
+
+  async function updateEntry(newData, previousEntry) {
+    const { japaneseInput, reading, englishInput } = newData;
+    const updatedEntry = {
+      ...previousEntry,
+      japanese: {
+        word: japaneseInput,
+        reading: reading,
+      },
+      english: englishInput.split(", "),
+      study: {
+        ...previousEntry.study,
+        stage: 0,
+        streak: 0,
+      },
+    };
+
+    // Update entry in database
+    const response = await fetch(`/api/word-list/${_id}`, {
+      method: "PUT",
+      body: JSON.stringify(updatedEntry),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.ok) {
+      databaseMutate();
+    }
+  }
+
+  return (
+    <Modal>
+      <StyledCenteredCard>
+        <StyledSecondaryButton
+          type="button"
+          onClick={() => setIsDetailEditMode(false)}
+        >
+          <span
+            className="inherit-background-color"
+            role="img"
+            aria-label="exit"
+          >
+            <WrongIcon height="16px" width="16px" />
+          </span>
+        </StyledSecondaryButton>
+        <h2 className="inherit-background-color">Edit your Entry</h2>
+
+        <StyledForm
+          onSubmit={handleFormSubmit}
+          aria-labelledby="add-form-title"
+        >
+          <StyledFormLabel htmlFor="english-input">English</StyledFormLabel>
+          <StyledFormInput
+            type="text"
+            id="english-input"
+            name="englishInput"
+            defaultValue={previousEnglish}
+            required
+          />
+          <StyledFormLabel htmlFor="japanese-input">Japanese</StyledFormLabel>
+          <StyledFormInput
+            onChange={(event) =>
+              (event.target.value = convertToKana(event.target.value))
+            }
+            type="text"
+            id="japanese-input"
+            name="japaneseInput"
+            defaultValue={previousJapanese}
+            required
+          />
+          <StyledFormLabel htmlFor="reading">Reading</StyledFormLabel>
+          <StyledFormInput
+            onChange={(event) =>
+              (event.target.value = convertToKana(event.target.value))
+            }
+            type="text"
+            id="reading"
+            name="reading"
+            defaultValue={previousReading}
+          />
+          <StyledSubmitButton type="submit">Save</StyledSubmitButton>
+          <p className="inherit-background-color">
+            Saving will cause your study progress to be reset to 0.
+          </p>
+        </StyledForm>
+      </StyledCenteredCard>
+    </Modal>
+  );
+}
+
+const StyledCenteredCard = styled(StyledCard)`
+  position: fixed;
+  transform: translate(50%, -50%);
+  top: 50%;
+  right: 50%;
+`;
+
+export default EditingForm;

--- a/components/EntriesContainer/index.js
+++ b/components/EntriesContainer/index.js
@@ -9,6 +9,8 @@ function EntriesContainer({
   databaseIsLoading,
   isEditMode,
   databaseMutate,
+  isDetailEditMode,
+  setIsDetailEditMode,
 }) {
   if (databaseIsLoading) {
     return (
@@ -24,6 +26,8 @@ function EntriesContainer({
             return (
               <Entry
                 isEditMode={isEditMode}
+                isDetailEditMode={isDetailEditMode}
+                setIsDetailEditMode={setIsDetailEditMode}
                 key={entry._id}
                 entry={entry}
                 handleAddEntry={handleAddEntry}

--- a/components/Entry/index.js
+++ b/components/Entry/index.js
@@ -13,8 +13,17 @@ import EntryContent from "../EntryContent";
 import DeleteIcon from "@/assets/icons/DeleteIcon";
 import CorrectIcon from "@/assets/icons/CorrectIcon";
 import AddIcon from "@/assets/icons/AddIcon";
+import EditIcon from "@/assets/icons/EditIcon";
+import { useRouter } from "next/router";
 
-function Entry({ entry, handleAddEntry, isEditMode, databaseMutate }) {
+function Entry({
+  entry,
+  handleAddEntry,
+  isEditMode,
+  databaseMutate,
+  setIsDetailEditMode,
+}) {
+  const router = useRouter();
   const { _id, showAddButton, isDictionaryEntry } = entry;
 
   if (_id) {
@@ -45,6 +54,21 @@ function Entry({ entry, handleAddEntry, isEditMode, databaseMutate }) {
                 <DeleteIcon width="16px" height="16px" />
               </span>
             </StyledSecondaryButton>
+            <StyledSubmitButton
+              type="button"
+              onClick={() => {
+                setIsDetailEditMode(true);
+                router.push(`/words/${_id}`);
+              }}
+            >
+              <span
+                className="inherit-background-color"
+                role="img"
+                aria-label="edit"
+              >
+                <EditIcon width="16px" height="16px" />
+              </span>
+            </StyledSubmitButton>
           </StyledEditComponent>
         )}
       </PositionRelativeDiv>
@@ -115,14 +139,13 @@ const StyledEditComponent = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
+  gap: 0.3rem;
   top: 0;
-  right: -20px;
+  padding: 10px;
+  right: -30px;
   z-index: 1;
 
   @media ${device.tablet} {
-    background-color: transparent;
-    display: flex;
-    flex-direction: column;
     margin-left: -35px;
   }
 `;

--- a/components/StyledComponents/Modal.js
+++ b/components/StyledComponents/Modal.js
@@ -1,0 +1,11 @@
+import { device } from "@/utils/globalValues";
+import styled from "styled-components";
+
+export const Modal = styled.main`
+  position: fixed;
+  top: 0;
+  background-color: var(--overlay);
+  width: 100vw;
+  height: 100vh;
+  z-index: 5;
+`;

--- a/components/StyledComponents/StyledButtons.js
+++ b/components/StyledComponents/StyledButtons.js
@@ -4,12 +4,13 @@ export const StyledSubmitButton = styled.button`
   align-self: flex-end;
   background-color: var(--highlight-red);
   color: var(--white);
-  padding: 10px 15px;
+  padding: 8px 13px;
   border: none;
   border-radius: 25px;
   box-shadow: var(--default-box-shadow);
   font-weight: 500;
   font-size: 1.2rem;
+  line-height: 1.2rem;
 
   &:disabled {
     background-color: var(--light-grey);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,6 +24,7 @@ export default function App({ Component, pageProps }) {
   const [dictionaryQuery, setDictionaryQuery] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [dictionaryResults, setDictionaryResults] = useState([]);
+  const [isDetailEditMode, setIsDetailEditMode] = useState(false);
 
   // Fetching from Dictionary
   const DictionaryURL = `/api/dictionary-search/${dictionaryQuery}`;
@@ -125,6 +126,8 @@ export default function App({ Component, pageProps }) {
         dictionaryResults={dictionaryResults}
         setDictionaryResults={setDictionaryResults}
         dictionaryIsLoading={dictionaryIsLoading}
+        setIsDetailEditMode={setIsDetailEditMode}
+        isDetailEditMode={isDetailEditMode}
         {...pageProps}
       />
       <Layout />

--- a/pages/words/[id].js
+++ b/pages/words/[id].js
@@ -1,3 +1,5 @@
+import EditIcon from "@/assets/icons/EditIcon";
+import EditingForm from "@/components/EditingForm";
 import {
   StyledDefinition,
   StyledJPDefinition,
@@ -5,7 +7,10 @@ import {
 } from "@/components/Entry";
 import { StyledResultDisplay } from "@/components/SearchResults";
 import { MainContent } from "@/components/StyledComponents/MainContent";
-import { StyledSecondaryButton } from "@/components/StyledComponents/StyledButtons";
+import {
+  StyledSecondaryButton,
+  StyledSubmitButton,
+} from "@/components/StyledComponents/StyledButtons";
 import { StyledCard } from "@/components/StyledComponents/StyledCard";
 import {
   StyledCenterAlign,
@@ -13,10 +18,17 @@ import {
 } from "@/components/StyledComponents/StyledSection";
 import { getVisualDate } from "@/utils/helperFunctions";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 import styled from "styled-components";
 
-export default function WordDetail({ wordList, databaseIsLoading }) {
+export default function WordDetail({
+  wordList,
+  databaseIsLoading,
+  databaseMutate,
+  isDetailEditMode,
+  setIsDetailEditMode,
+}) {
   const router = useRouter();
   const { id } = router.query;
 
@@ -42,11 +54,34 @@ export default function WordDetail({ wordList, databaseIsLoading }) {
     const visualReviewDate = getVisualDate(lastReview);
     return (
       <MainContent>
+        {isDetailEditMode && (
+          <EditingForm
+            setIsDetailEditMode={setIsDetailEditMode}
+            previousEnglish={english}
+            previousJapanese={japanese.word}
+            previousReading={japanese.reading}
+            entry={entryData}
+            _id={id}
+            databaseMutate={databaseMutate}
+          />
+        )}
         <StyledCenterAlign>
           <StyledSectionLeftAlign>
             <StyledSecondaryButton type="button" onClick={() => router.back()}>
               Back
             </StyledSecondaryButton>
+            <StyledSubmitButton
+              type="button"
+              onClick={() => setIsDetailEditMode(true)}
+            >
+              <span
+                className="inherit-background-color"
+                role="img"
+                aria-label="edit"
+              >
+                <EditIcon height="20px" width="20px" />
+              </span>
+            </StyledSubmitButton>
           </StyledSectionLeftAlign>
 
           <StyledCard>

--- a/pages/words/index.js
+++ b/pages/words/index.js
@@ -11,6 +11,7 @@ export default function WordList({
   wordList,
   databaseIsLoading,
   databaseMutate,
+  setIsDetailEditMode,
 }) {
   const [isEditMode, setIsEditMode] = useState(false);
 
@@ -43,6 +44,7 @@ export default function WordList({
       </StyledSectionRightAlign>
       <EntriesContainer
         isEditMode={isEditMode}
+        setIsDetailEditMode={setIsDetailEditMode}
         wordList={wordList}
         databaseIsLoading={databaseIsLoading}
         databaseMutate={databaseMutate}

--- a/styles.js
+++ b/styles.js
@@ -11,6 +11,7 @@ export default createGlobalStyle`
     --dark-main: #2E2836;
     --text-color: #30343F;
     --white: #ffffff; 
+    --overlay: rgba(203, 203, 2012, 0.8);
 
 /* HEIGHTS and WIDTHS */
 


### PR DESCRIPTION
As per [US12](https://github.com/JudithRe/capstone-flashcard-dictionary/issues/18)
- Created editing feature that is accessible from the word details page and the word list page (after clicking the editing button)